### PR TITLE
Back to use defused

### DIFF
--- a/xlrd/xlsx.py
+++ b/xlrd/xlsx.py
@@ -29,7 +29,7 @@ def ensure_elementtree_imported(verbosity, logfile):
     if ET is not None:
         return
 
-    candidates = ["lxml.etree", "defusedxml.cElementTree", "xml.etree.ElementTree"]
+    candidates = ["defusedxml.ElementTree", "lxml.etree", "xml.etree.ElementTree"]
     for name in candidates:
         try:
             lib = import_module(name)


### PR DESCRIPTION
So, it seems the slowness I observed was all down to my debugger. 🤦‍♂️ 
This puts back the defused parser which is similarly performant. We do still have the optimisation to only grab a handful of rows though which is a solid improvement